### PR TITLE
Fix message form send state

### DIFF
--- a/src/components/MessageForm.jsx
+++ b/src/components/MessageForm.jsx
@@ -12,15 +12,14 @@ export default function MessageForm() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (!message.trim()) return;
     setIsSending(true);
-    if (!message) return;
-
     setMessage("");
 
     try {
       const { error } = await supabase.from("messages").insert([
         {
-          text: message,
+          text: message.trim(),
           username,
           country,
           is_authenticated: session ? true : false,
@@ -40,7 +39,7 @@ export default function MessageForm() {
         });
         return;
       }
-      console.log("Sucsessfully sent!");
+      console.log("Successfully sent!");
     } catch (error) {
       console.log("error sending message:", error);
     } finally {
@@ -71,7 +70,7 @@ export default function MessageForm() {
               fontSize="20px"
               icon={<BiSend />}
               type="submit"
-              disabled={!message}
+              disabled={!message.trim()}
               isLoading={isSending}
             >
               <BiSend />


### PR DESCRIPTION
## Summary
- avoid leaving spinner active when no message is entered
- trim messages before sending
- prevent send with only whitespace
- fix typo in console log

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ae34a54a0832cb618c01496a8f900